### PR TITLE
Fix units wording to make it clearly

### DIFF
--- a/pages/css-styleguide/units.md
+++ b/pages/css-styleguide/units.md
@@ -15,7 +15,7 @@ This can be done with the following mixin:
 }
 ```
 
-- Set the HTML font size to 10px to ensure .1 rem unit equals 1px.
+- Set the HTML font size to 10px to ensure 0.1 rem unit equals 1px.
 
 ```scss
 html {


### PR DESCRIPTION
Use `0.1 rem` instead of `.1 rem` to improve readability. Close #92